### PR TITLE
Fix Tags

### DIFF
--- a/src/repository/mongo/TypeRepository.ts
+++ b/src/repository/mongo/TypeRepository.ts
@@ -5,9 +5,9 @@ import { StudyModel } from "../../model/Study"
 import { ActivityModel } from "../../model/Activity"
 import { SensorModel } from "../../model/Sensor"
 import { ResearcherModel } from "../../model/Researcher"
-import { TagsModel } from "../../model/Type"
 import { Repository } from "../../repository/Bootstrap"
 import { TypeInterface } from "../interface/RepositoryInterface"
+import mongoose from "mongoose"
 // FIXME: Support application/json;indent=:spaces format mime type!
 
 export class TypeRepository implements TypeInterface {
@@ -38,7 +38,7 @@ export class TypeRepository implements TypeInterface {
       if (null !== data) return "Activity"
     } catch (e) {}
     try {
-      const data: any = await (SensorModel.findOne({ _deleted: false, _id: type_id }) as any)
+      const data: any = await (SensorModel.findOne({ _deleted: false, _id: type_id }).maxTimeMS(60000) as any)
       if (null !== data) return "Sensor"
     } catch (e) {}
     return "__broken_id__"
@@ -92,37 +92,19 @@ export class TypeRepository implements TypeInterface {
 
   public async _set(mode: any, type: string, type_id: string, key: string, value?: any): Promise<{}> {
     const deletion = value === undefined || value === null
-    let existing: any = ""
-    existing = await TagsModel.findOne({ _deleted: false, _parent: type_id, type: type, key: key }).maxTimeMS(60000)
-    if (existing === null && !deletion) {
-      try {
-        await TagsModel.create([{
-         _parent: type_id,
-         type,
-         key,
-         value: JSON.stringify(value)}],{checkKeys:false})
-      } catch (e) {
-        console.error(e)
-        throw new Error("500.creation-or-update-failed")
-      }
-    } else if (existing !== null && !deletion) {
-      try {
-        const data: any = await TagsModel.findByIdAndUpdate(existing._id, { value: JSON.stringify(value) })
-      } catch (e) {
-        console.error(e)
-        throw new Error("400.update-failed")
-      }
-    } else if (existing !== null) { // an existing document MUST exist to delete it.
-      // DELETE
-      try {
-        await TagsModel.updateOne({ _id: existing._id }, { _deleted: true })
-      } catch (e) {
-        console.error(e)
-        // If we try to delete a non-existing Tag it should still succeed.
-        //throw new Error("400.deletion-failed")
-      }
-    }
-
+    const output = await mongoose.connection.collection("tag").findOneAndUpdate(
+        { _parent: type_id, type: type, key: key }, 
+        { 
+            $set: { 
+                _deleted: deletion,
+                value: deletion ? null : JSON.stringify(value)
+            }, 
+            $setOnInsert: {
+                _parent: type_id, type: type, key: key
+            }
+        },
+        { upsert: true, maxTimeMS: 60000 }
+    )
     return {}
   }
 
@@ -151,7 +133,7 @@ export class TypeRepository implements TypeInterface {
     //     multiple keys per-subquery; the difference is almost ~7sec vs. ~150ms.
     for (const condition of conditions) {
       try {
-        const value = await TagsModel.find(condition).limit(1).maxTimeMS(60000)
+        const value = await mongoose.connection.collection("tag").find(condition).limit(1).maxTimeMS(60000).toArray()
         if (value.length > 0) return value.map((x: any) => JSON.parse(x.value))[0]
       } catch (error) {
         console.error(error, `Failed to search Tag index for ${condition._parent}:${condition.type}.`)
@@ -188,7 +170,7 @@ export class TypeRepository implements TypeInterface {
     let all_keys: string[] = []
     for (const condition of conditions) {
       try {
-        const value = await TagsModel.find(condition).limit(2_147_483_647).maxTimeMS(60000)
+        const value = await mongoose.connection.collection("tag").find(condition).limit(2_147_483_647).maxTimeMS(60000).toArray()
         all_keys = [...all_keys, ...value.map((x: any) => x.key as any)]
       } catch (error) {
         console.error(error, `Failed to search Tag index for ${condition._parent}:${condition.type}.`)
@@ -201,155 +183,6 @@ export class TypeRepository implements TypeInterface {
     if (all_keys.length > 0) return [...new Set(all_keys)]
     else throw new Error("404.object-not-found")
   }
-
-  /*public async _invoke(attachment: DynamicAttachment, context: any): Promise<any | undefined> {
-    if ((attachment.contents || "").trim().length === 0) return undefined
-    // Select script runner for the right language...
-    let runner: ScriptRunner
-    switch (attachment.language) {
-      case "rscript":
-        runner = new ScriptRunner.R()
-        break
-      case "python":
-        runner = new ScriptRunner.Py()
-        break
-      case "javascript":
-        runner = new ScriptRunner.JS()
-        break
-      case "bash":
-        runner = new ScriptRunner.Bash()
-        break
-      default:
-        throw new Error("400.invalid-script-runner")
-    }
-    // Execute script.
-    return await runner.execute(attachment.contents!, attachment.requirements!.join(","), context)
-  }*/
-
-  /*public async _process_triggers(): Promise<void> {
-    // FIXME: THIS FUNCTION IS DEPRECATED/OUT OF DATE/DISABLED (!!!)
-    console.log("Processing accumulated attachment triggers...")
-
-    // Request the set of all updates.
-    const accumulated_set = (
-      await SQL!.request().query(`
-			SELECT 
-				Type, ID, Subtype, 
-				DATEDIFF_BIG(MS, '1970-01-01', LastUpdate) AS LastUpdate, 
-				Users.StudyId AS _SID,
-				Users.AdminID AS _AID
-			FROM LAMP_Aux.dbo.UpdateCounter
-			LEFT JOIN LAMP.dbo.Users
-				ON Type = 'Participant' AND Users.UserID = ID
-			ORDER BY LastUpdate DESC;
-		`)
-    ).recordset.map((x: any) => ({
-      ...x,
-      _id:
-        x.Type === "Participant"
-          ? Participant_pack_id({ study_id: x._SID }) // FIXME: Decrypt(<string>x._SID)
-          : Researcher_pack_id({ admin_id: x.ID }),
-      _admin:
-        x.Type === "Participant" ? Researcher_pack_id({ admin_id: x._AID }) : Researcher_pack_id({ admin_id: x.ID }),
-    }))
-    const ax_set1 = accumulated_set.map((x: any) => x._id)
-    const ax_set2 = accumulated_set.map((x: any) => x._admin)
-
-    // Request the set of event masks prepared.
-    const registered_set = (
-      await SQL!.request().query(`
-			SELECT * FROM LAMP_Aux.dbo.OOLAttachmentLinker; 
-		`)
-    ).recordset // TODO: SELECT * FROM LAMP_Aux.dbo.OOLTriggerSet;
-
-    // Diff the masks against all updates.
-    let working_set = registered_set.filter(
-      (x: any) =>
-        // Attachment from self -> self.
-        (x.ChildObjectType === "me" && ax_set1.indexOf(x.ObjectID) >= 0) ||
-        // Attachment from self -> children of type Participant
-        (x.ChildObjectType === "Participant" && ax_set2.indexOf(x.ObjectID) >= 0) ||
-        // Attachment from self -> specific child Participant matching an ID
-        accumulated_set.find((y: any) => y._id === x.ChildObjectType && y._admin === x.ObjectID) !== undefined
-    )
-
-    // Completely delete all updates; we're done collecting the working set.
-    // TODO: Maybe don't delete before execution?
-    const result = await SQL!.request().query(`
-            DELETE FROM LAMP_Aux.dbo.UpdateCounter;
-		`)
-    console.log("Resolved " + JSON.stringify(result.recordset) + " events.")
-
-    // Duplicate the working set into specific entries.
-    working_set = working_set
-      .map((x: any) => {
-        const script_type = x.ScriptType.startsWith("{")
-          ? JSON.parse(x.ScriptType)
-          : { triggers: [], language: x.ScriptType }
-
-        const obj = new DynamicAttachment()
-        obj.key = x.AttachmentKey
-        obj.from = x.ObjectID
-        obj.to = x.ChildObjectType
-        obj.triggers = script_type.triggers
-        obj.language = script_type.language
-        obj.contents = x.ScriptContents
-        obj.requirements = JSON.parse(x.ReqPackages)
-        return obj
-      })
-      .map((x: any) => {
-        // Apply a subgroup transformation only if we're targetting all
-        // child resources of a type (i.e. 'Participant').
-        if (x.to === "Participant")
-          return accumulated_set
-            .filter((y: any) => y.Type === "Participant" && y._admin === x.from && y._id !== y._admin)
-            .map((y: any) => ({ ...x, to: y._id }))
-        return [{ ...x, to: x.from as string }]
-      })
-    ;([] as any[]).concat(...working_set).forEach(async (x) =>
-      TypeRepository._invoke(x, {
-        // The security context originator for the script
-        // with a magic placeholder to indicate to the LAMP server
-        // that the script's API requests are pre-authenticated.
-        token: await CredentialRepository._packCosignerData(x.from, x.to),
-
-        // What object was this automation run for on behalf of an agent?
-        object: {
-          id: x.to,
-          type: TypeRepository._self_type(x.to),
-        },
-
-        // Currently meaningless but does signify what caused the IA to run.
-        event: ["ActivityEvent", "SensorEvent"],
-      })
-        .then((y) => {
-          TypeRepository._set("a", x.to, x.from as string, x.key + "/output", y)
-        })
-        .catch((err) => {
-          TypeRepository._set(
-            "a",
-            x.to,
-            x.from as string,
-            x.key + "/output",
-            JSON.stringify({ output: null, logs: err })
-          )
-        })
-    )
-    // TODO: This is for a single item only;
-    const type_id = ""
-    const attachments: DynamicAttachment[] = await Promise.all(
-      (await TypeRepository._list("b", type_id as string)).map(
-        async (x) => await TypeRepository._get("b", type_id as string, x)
-      )
-    )
-    attachments
-      .filter((x) => !!x.triggers && x.triggers.length > 0)
-      .forEach((x) =>
-        TypeRepository._invoke(x, null).then((y: any) => {
-          TypeRepository._set("a", x.to!, <string>x.from!, x.key! + "/output")
-        })
-      )
-  }*/
 }
 
 async function Researcher_parent_id(id: string, type: string): Promise<string | undefined> {


### PR DESCRIPTION
1. The previous implementation of `TypeRepository._set()` incorrectly creates duplicate documents. If a Tag is created, then deleted, and a new Tag is created with the same key, both the prior entry and the new entry exist in the database (one is deleted and one is not). **Instead, using the `findOneAndUpdate` with the `upsert` option correctly handles create, update, and delete cases.**
2. Mongoose causes unpredictable behavior when calling, for example, `TypeRepository._set()` and `TypeRepository._get()` immediately after, for the same key. The only way to resolve is is to add a `sleep(0.1)` delay to all client side API calls which is not acceptable. **Please convert the use of all Mongoose functions to appropriate native MongoDB driver functions. We are not even really using the ORM features of Mongoose anyway so it's causing unnecessary overhead.**