### PR TITLE
Jsonata tag set fix

### DIFF
--- a/src/service/Query.ts
+++ b/src/service/Query.ts
@@ -280,11 +280,11 @@ const METHOD_LIST = (auth: any) => ({
         console.log(` -- LAMP.Tag.get: ${((Date.now() - _start)).toFixed(2)} ms`)
         return x 
       },
-      set: async (type_id: string, attachment_key: string, target: string, attachment_value: string) => {
+      set: async (type_id: string,  target: string, attachment_key: string, attachment_value: string) => {
         const _start = Date.now()
         let x = null // error
         try {
-          x = await TypeService.set(auth, type_id, attachment_key, target, attachment_value)
+          x = await TypeService.set(auth, type_id, target, attachment_key, attachment_value)
         } catch (e) {}
         console.log(` -- LAMP.Tag.set: ${((Date.now() - _start)).toFixed(2)} ms`)
         return x 

--- a/src/service/TypeService.ts
+++ b/src/service/TypeService.ts
@@ -141,8 +141,8 @@ TypeService.Router.put(_put_routes, async (req: Request, res: Response) => {
       data: (await TypeService.set(
         req.get("Authorization"),
         req.params.type_id === "null" ? null : req.params.type_id,
-        req.params.attachment_key,
         req.params.target,
+        req.params.attachment_key,
         req.body
       ))
         ? {}

--- a/src/service/TypeService.ts
+++ b/src/service/TypeService.ts
@@ -51,8 +51,8 @@ export class TypeService {
   public static async set(
     auth: any,
     type_id: string | null,
-    attachment_key: string,
     target: string,
+    attachment_key: string,
     attachment_value: any
   ) {
     const TypeRepository = new Repository().getTypeRepository()


### PR DESCRIPTION
This PR fixes incorrectly ordered params that made it unintuitive to set tags through the LAMP JSONata document transform system. 