### PR TITLE
fix: fixes Husky's tsc pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+npm run checkTs
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "start-sw": "dotenv node build/src/index.js",
     "start": "npm run build && npm run start-sw",
     "test": "jest --watch",
+    "checkTs": "tsc --noEmit",
     "lint": "eslint src/**/*.ts",
     "prepare": "husky install"
   },
@@ -91,7 +92,6 @@
   "lint-staged": {
     "*.js": "eslint --cache --fix",
     "**/*.ts?(x)": [
-      "tsc -p tsconfig.json --noEmit",
       "eslint --cache --fix"
     ]
   }


### PR DESCRIPTION
Running `tsc` in a pre-commit hook has a known issue (see: microsoft/TypeScript#27379). Until this is fixed upstream pull the tsc check out as an npm script and explicitly run it.

This does mean any Typescript compile issues in the repository will cause a commit to fail even if they're not being committed. 