### PR TITLE
fix: Add dev dashboard to CORS origins

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ app.use(express.text())
 app.use(
   cors({
     origin: [
+      "https://dashboard.dev.lamp.digital/",
       "https://dashboard-staging.lamp.digital",
       "https://dashboard.lamp.digital",
       "https://lamp-dashboard.zcodemo.com",

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,7 @@ app.use(express.text())
 app.use(
   cors({
     origin: [
-      "https://dashboard.dev.lamp.digital/",
+      "https://dashboard.dev.lamp.digital",
       "https://dashboard-staging.lamp.digital",
       "https://dashboard.lamp.digital",
       "https://lamp-dashboard.zcodemo.com",


### PR DESCRIPTION
Quick fix to add the Development dashboard url to the CORS origins list