### PR TITLE
Environment variable updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@
 | `PUSH_GATEWAY_APIKEY`   |   |   |
 | `REDIS_HOST`  | :heavy_check_mark:  |   |
 | `ROOT_KEY`   | :heavy_check_mark:  |   |
+| `SYSTEM_STATUS_API_KEY`   |   | If set, some of the system info endpoints (such as `/system/metrics` or `/system/version`) will require a `key` query parameter equal to this env var in order to access.  |
 | `secret_key`   |   |   |
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 | `PUSH_GATEWAY_APIKEY`   |   |   |
 | `REDIS_HOST`  | :heavy_check_mark:  |   |
 | `ROOT_KEY`   | :heavy_check_mark:  |   |
+| `SHUTDOWN_GRACEPERIOD_MS`   | | The number of milliseconds after the process receives a termination signal before forcibly closing connections.  |
 | `SYSTEM_STATUS_API_KEY`   |   | If set, some of the system info endpoints (such as `/system/metrics` or `/system/version`) will require a `key` query parameter equal to this env var in order to access.  |
 | `secret_key`   |   |   |
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@
 | `DASHBOARD_URL`   | :heavy_check_mark:  |   |
 | `DB`  | :heavy_check_mark:  |   |
 | `DB_KEY`   |   |   |
-| `HTTPS`   |   |   |
 | `NATS_SERVER`   | :heavy_check_mark:  |   |
-| `PORT`   |   |   |
+| `PORT`   |   | The port number the server should listen on. Defaults to 3000.  |
 | `PUSH_API_KEY`   |   |   |
 | `PUSH_GATEWAY`   |   |   |
 | `PUSH_GATEWAY_APIKEY`   |   |   |

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,9 +48,8 @@
         "nodemon": "^3.1.10",
         "prettier": "^2.8.8",
         "rimraf": "^6.0.1",
-        "source-map-support": "^0.5.16",
         "ts-jest": "^28.0.2",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "^4.7.4"
       }
     },
@@ -574,6 +573,30 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
@@ -1399,6 +1422,34 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1958,6 +2009,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ansi-escapes": {
@@ -8744,17 +8808,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -9227,30 +9280,47 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
       },
-      "engines": {
-        "node": ">=10.0.0"
-      },
       "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
         "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/tslib": {
@@ -9550,6 +9620,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prettier": "^2.8.8",
     "rimraf": "^6.0.1",
     "ts-jest": "^28.0.2",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.9.2",
     "typescript": "^4.7.4"
   },
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
 import http from "http"
-import https from "https"
-import { HTTPS_CERT } from "./utils"
 import { Bootstrap } from "./repository/Bootstrap"
 import app from "./app"
 
@@ -17,18 +15,12 @@ async function main(): Promise<void> {
   console.groupEnd()
   console.log("Initialization complete.")
 
-  const port = process.env.PORT || 3000
+  const PORT: number = parseInt(process.env.PORT || "3000");
 
-  let _server: http.Server | https.Server
-  if (process.env.HTTPS && process.env.HTTPS !== "off") {
-    console.info("Starting HTTPS server on port ", port)
-    console.warn("Server is using default HTTPS certificates. Don't do this.")
-    _server = https.createServer(HTTPS_CERT, app)
-  } else {
-    console.info("Starting HTTP server on port ", port)
-    _server = http.createServer(app)
-  }
-  _server.listen(port)
+  const server = http.createServer(app)
+  server.listen(PORT, "0.0.0.0", () => {
+    console.log(`Server listening on port ${PORT}`)
+  })
 
   /**
    * Shuts down the server and exists the process.
@@ -36,7 +28,7 @@ async function main(): Promise<void> {
    */
   function shutdown() {
     console.info("LAMP shutting down")
-    _server.close(() => {
+    server.close(() => {
       console.info("LAMP shut down")
       process.exit(0)
     })


### PR DESCRIPTION
Few updates to environment variables..

- `SYSTEM_STATUS_API_KEY`: Documented in readme. Also, only guards version and metrics endpoints. `/readyz` and `/healthz` are always available on unprotected routes
- `PORT`: can and should be parsing the env var to an int. All env vars are strings or not defined.
- `HTTPS`: removed the remaining logic to toggle on an https server -- all our https servering is done in nginx or in our load balancer
- `SHUTDOWN_GRACEPERIOD_MS`: Same as our [app-gateway](https://github.com/BIDMCDigitalPsychiatry/LAMP-app-gateway/blob/master/src/server.ts#L33-L53). If connections are still in flight after `SIGINT` or `SIGTERM` are received, give them this much time to terminate before forcibly terminating them.

.. also, update `ts-node`, which is mad about some typescript type somewhere :thinking: 