### PR TITLE
Local development improvements: Add example.env for easier first time set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,36 @@
 
 [To learn more about the LAMP Platform, visit our documentation.](https://docs.lamp.digital/)
 
-## Environment
+## Setup For Local Development
 
-| Name  | Required | Description  |
-|---|---|---|
-| `APP_GATEWAY`   |   | **Deprecated**. Use `NOTIFICATION_SERVICE_URL`.  |
-| `CACHE_FLUSH_ALL`   |   |   |
-| `CACHE_SIZE`   |   |   |
-| `CDB`   |   | **Deprecated**. Couch DB is no longer used. |
-| `DASHBOARD_URL`   | :heavy_check_mark:  |   |
-| `DB`  | :heavy_check_mark:  |   |
-| `DB_KEY`   |   |   |
-| `NATS_SERVER`   | :heavy_check_mark:  |   |
-| `NOTIFICATION_SERVICE_API_KEY`   |   | The api key to be used when addressing the designated notification service.  |
-| `NOTIFICATION_SERVICE_URL`   |  | The protocol scheme, hostname, and optionally port that points to the desired notification service.  |
-| `PORT`   |   | The port number the server should listen on. Defaults to 3000.  |
-| `PUSH_API_KEY`   |   | **Deprecated**. Use `NOTIFICATION_SERVICE_API_KEY`.  |
-| `PUSH_GATEWAY`   |   | **Deprecated**. Use `NOTIFICATION_SERVICE_URL`.  |
-| `PUSH_GATEWAY_APIKEY`   |   | **Deprecated**. Use `NOTIFICATION_SERVICE_API_KEY`.  |
-| `REDIS_HOST`  | :heavy_check_mark:  |   |
-| `ROOT_KEY`   | :heavy_check_mark:  |   |
-| `SHUTDOWN_GRACEPERIOD_MS`   | | The number of milliseconds after the process receives a termination signal before forcibly closing connections.  |
-| `SYSTEM_STATUS_API_KEY`   |   | If set, some of the system info endpoints (such as `/system/metrics` or `/system/version`) will require a `key` query parameter equal to this env var in order to access.  |
+1. Run `npm install`
+2. Copy `example.env` and rename the copy to `.env`
+3. Fill out the required fields of the new `.env` file. `example.env` contains example values that work for local development.
+4. Ensure that docker is installed and can be run without using `sudo`.
+5. Ensure that mongodb is installed and running.
+6. Run `npm run dev`. Take note of the administrator password the command will print out the first time it is run successfully.
+7. Log into the server via the dashboard using "admin" as the e-mail, and the password from step 6.
+
+### Environment
+
+| Name  | Required | Description                                                                                                                                                               |
+|---|---|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `APP_GATEWAY`   |   | **Deprecated**. Use `NOTIFICATION_SERVICE_URL`.                                                                                                                           |
+| `CACHE_FLUSH_ALL`   |   |                                                                                                                                                                           |
+| `CACHE_SIZE`   |   |                                                                                                                                                                           |
+| `CDB`   |   | **Deprecated**. Couch DB is no longer used.                                                                                                                               |
+| `DASHBOARD_URL`   | :heavy_check_mark:  |                                                                                                                                                                       |
+| `DB`  | :heavy_check_mark:  | Database connection string.                                                                                                                                               |
+| `DB_KEY`   |   |                                                                                                                                                                           |
+| `NATS_SERVER`   | :heavy_check_mark:  |                                                                                                                                                                           |
+| `NOTIFICATION_SERVICE_API_KEY`   |   | The api key to be used when addressing the designated notification service.                                                                                               |
+| `NOTIFICATION_SERVICE_URL`   |  | The protocol scheme, hostname, and optionally port that points to the desired notification service.                                                                       |
+| `PORT`   |   | The port number the server should listen on. Defaults to 3000.                                                                                                            |
+| `PUSH_API_KEY`   |   | **Deprecated**. Use `NOTIFICATION_SERVICE_API_KEY`.                                                                                                                       |
+| `PUSH_GATEWAY`   |   | **Deprecated**. Use `NOTIFICATION_SERVICE_URL`.                                                                                                                           |
+| `PUSH_GATEWAY_APIKEY`   |   | **Deprecated**. Use `NOTIFICATION_SERVICE_API_KEY`.                                                                                                                       |
+| `REDIS_HOST`  | :heavy_check_mark:  |                                                                                                                                                                           |
+| `ROOT_KEY`   | :heavy_check_mark:  | An key used to encrypt credentials.                                                                                                                                       |
+| `SHUTDOWN_GRACEPERIOD_MS`   | | The number of milliseconds after the process receives a termination signal before forcibly closing connections.                                                           |
+| `SYSTEM_STATUS_API_KEY`   |   | If set, some of the system info endpoints (such as `/system/metrics` or `/system/version`) will require a `key` query parameter equal to this env var in order to access. |
 

--- a/example.env
+++ b/example.env
@@ -1,0 +1,23 @@
+# Make a copy of this file named .env and fill in the required variables
+
+# === Required ===
+DASHBOARD_URL="https://dashboard.dev.lamp.digital"
+# Port numbers for DB, redis host, push gateway and nats server are based on port numbers used in docker-compose.yaml
+DB="mongodb://root:password@localhost:27017/"
+REDIS_HOST="redis://localhost:6379"
+PUSH_GATEWAY="http://localhost:8111"
+NATS_SERVER="tcp://localhost:4222"
+
+# A key can be generated for local development using openssl: `openssl enc -aes-256-cbc -k secret -P -md sha1`
+ROOT_KEY=
+
+# === Optional ===
+NOTIFICATION_SERVICE_URL=http://localhost:3000
+PORT=8083
+PUSH_API_KEY=
+SHUTDOWN_GRACEPERIOD_MS=3000
+
+# === Sentry configuration ===
+# SENTRY_DSN=""
+# SENTRY_ENV=""
+# SYSTEM_STATUS_API_KEY=""

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,15 +10,20 @@ app.set("json spaces", 2)
 app.use(express.json({ limit: "50mb", strict: false }))
 app.use(express.text())
 
-app.use(
-  cors({
-    origin: [
+const allowedOrigins = [
       "https://dashboard.dev.lamp.digital",
       "https://dashboard-staging.lamp.digital",
       "https://dashboard.lamp.digital",
       "https://lamp-dashboard.zcodemo.com",
       "https://lamp-secdash.zcodemo.com",
-    ],
+]
+if (process.env.DASHBOARD_URL) {
+  allowedOrigins.push(process.env.DASHBOARD_URL)
+}
+
+app.use(
+  cors({
+    origin: allowedOrigins,
     credentials: true,
     methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
     allowedHeaders: [


### PR DESCRIPTION
This pr adds an `example.env` file to make it easier for new contributors to start running the server for the first time.