### PR TITLE
Hotfix v2.0.1: Remove sibling permissions from participant data routes

### DIFF
--- a/src/loadTestData.ts
+++ b/src/loadTestData.ts
@@ -1,0 +1,338 @@
+import { Bootstrap, Repository } from "./repository/Bootstrap";
+import app from "./app"; // This import is unused but is required for Bootstrap to run correctly
+import { exit } from "process";
+
+const RESEARCHER_COUNT = 3
+const PER_STUDY_PARTICIPANT_COUNT = 3
+
+const ACTIVITY_SPECS = [
+    {
+        "_id": "lamp.goals",
+        "description": null,
+        "executable": "https://raw.githubusercontent.com/BIDMCDigitalPsychiatry/LAMP-activities/dist/out/goals.html.b64",
+        "static_data": {},
+        "temporal_slices": {},
+        "settings": {},
+        "category": null,
+    },
+    {
+        "_id": "lamp.survey",
+        "_parent": null,
+        "_rev": "1-967a00dff5e02add41819138abb3284d",
+        "category": null,
+        "executable": "https://raw.githubusercontent.com/BIDMCDigitalPsychiatry/LAMP-activities/dist/out/survey.html.b64",
+        "help_contents": null,
+        "script_contents": null,
+        "settings_schema": null,
+        "static_data_schema": null,
+        "temporal_slice_schema": null
+    },
+    {
+    "_id": "lamp.medications",
+    "description": null,
+    "executable": "https://raw.githubusercontent.com/BIDMCDigitalPsychiatry/LAMP-activities/dist/out/medications.html.b64",
+    "static_data": {},
+    "temporal_slices": {},
+    "settings": {},
+    "category": null,
+    "_deleted": false
+},
+]
+const ACTIVITIES = [
+    {
+        "spec": "lamp.goals",
+        "name": "goals",
+        "settings": {
+            "unit": "meter",
+            "value": 10
+        },
+        "schedule": [],
+        "category": [
+            "assess"
+        ],
+    },
+    {
+        "spec": "lamp.medications",
+        "name": "Medication 1",
+        "settings": {
+            "unit": "Kg",
+            "value": 10
+        },
+        "schedule": [
+            {
+                "start_date": "2022-07-12T01:00:00.000Z",
+                "time": "2022-07-12T11:00:00.000Z",
+                "custom_time": null,
+                "repeat_interval": "every6h",
+                "notification_ids": [
+                    422038
+                ]
+            }
+        ],
+        "category": [
+            "manage"
+        ],
+    },
+    {
+            "spec": "lamp.survey",
+            "name": "Survey 1",
+            "settings": [
+                {
+                    "text": "Text: Today I have had thoughts racing through my head",
+                    "type": "text",
+                    "required": true
+                },
+                {
+                    "text": "List: Today I feel confused or puzzled",
+                    "type": "list",
+                    "options": [
+                        "Nearly All the Time",
+                        "More than Half the Time",
+                        "Several Times"
+                    ],
+                    "required": true
+                },
+                {
+                    "text": "Multiselect: In the last THREE DAYS, I have...",
+                    "type": "multiselect",
+                    "options": [
+                        "Walked somewhere",
+                        "Taken the bus",
+                        "Driven a car",
+                        "Taken a train",
+                        "Taken a plan"
+                    ],
+                    "required": true
+                },
+                {
+                    "text": "Slider: In the last THREE DAYS, I have felt uneasy with groups of people slider",
+                    "type": "slider",
+                    "options": [
+                        0,
+                        1,
+                        2
+                    ],
+                    "required": true
+                },
+                {
+                    "text": "Short Answer: In the last three days I felt uneasy",
+                    "type": "short",
+                    "required": false
+                },
+                {
+                    "text": "Rating: Today I feel unable to cope and have difficulty with everyday tasks",
+                    "type": "rating",
+                    "options": [
+                        0,
+                        1,
+                        2,
+                        3
+                    ],
+                    "required": true
+                },
+                {
+                    "text": "Time: Today I have heard voices or saw things others cannot",
+                    "type": "time",
+                    "options": [
+                        {
+                            "value": "standard"
+                        }
+                    ],
+                    "required": true
+                },
+                {
+                    "text": "Likert: Today I have had thoughts racing through my head",
+                    "type": "likert",
+                    "required": true
+                },
+            ],
+            "schedule": [
+                {
+                    "start_date": "2022-07-12T01:00:00.000Z",
+                    "time": "2022-07-12T10:00:00.000Z",
+                    "custom_time": null,
+                    "repeat_interval": "hourly",
+                    // "notification_ids": [
+                    //     965627
+                    // ]
+                }
+            ],
+            "category": [
+                "assess"
+            ],
+        },
+]
+
+const SENSOR_SPECS = [
+    {
+        "_id": "lamp.heart_rate",
+        "_parent": null,
+        "_rev": "4-6df412d924dccc1495029bcef4bb6f1a",
+        "type": "object",
+        "properties": {
+            "value": {
+                "type": "number"
+            },
+            "units": {
+                "type": "string"
+            }
+        },
+        "description": "",
+        "required": {},
+        "additionalProperties": false
+    },
+    {
+        "_id": "lamp.sleep",
+        "_parent": null,
+        "_rev": "4-8f4ba2cb84c4bf7f8378856cf1f08ce3",
+        "type": "object",
+        "properties": {
+            "value": {
+                "type": "number"
+            },
+            "event_type": {
+                "type": "string",
+                "enum": [
+                    "in_bed",
+                    "in_sleep",
+                    "in_awake"
+                ]
+            }
+        },
+        "description": "",
+        "required": {},
+        "additionalProperties": false,
+        "settings_schema": null
+    },
+    {
+        "_id": "lamp.telephony",
+        "_parent": null,
+        "_rev": "2-22d99a300c056762b1804a63a57a9b71",
+        "type": "object",
+        "properties": {
+            "type": {
+                "type": "string",
+                "enum": [
+                    "incoming",
+                    "outgoing",
+                    "missed",
+                    "busy"
+                ]
+            },
+            "duration": {
+                "type": "number"
+            },
+            "trace": {
+                "type": "string"
+            }
+        },
+        "description": "",
+        "required": {},
+        "additionalProperties": false,
+        "settings_schema": null
+    }
+]
+
+const SENSORS = [
+    {
+        "spec": "lamp.heart_rate",
+        "name": "heartrate",
+        "settings": {},
+    },
+    {
+        "spec": "lamp.telephony",
+        "name": "phone",
+        "settings": {},
+    },
+    {
+        "spec": "lamp.sleep",
+        "name": "sleep",
+        "settings": {},
+    },
+]
+
+async function loadTestData() {
+    const TEST_PASSWORD = process.env.TEST_DATA_PASSWORD || "Welcome1!"
+    const TEST_EMAIL_DOMAIN = process.env.TEST_DATA_EMAIL_DOMAIN
+
+    if ((!TEST_PASSWORD) || (!TEST_EMAIL_DOMAIN)) {
+        throw new Error("You must define TEST_DATA_PASSWORD and TEST_DATA_EMAIL_DOMAIN in your .env file to create test data")
+    }
+
+    await Bootstrap()
+
+
+
+    const repository = new Repository()
+
+    const ResearcherRepository = repository.getResearcherRepository()
+    const StudyRepository = repository.getStudyRepository()
+    const ActivityRepository = repository.getActivityRepository()
+    const SensorRepository = repository.getSensorRepository()
+    const ParticipantRepository = repository.getParticipantRepository()
+    const TypeRepository = repository.getTypeRepository()
+    const CredentialRepository = repository.getCredentialRepository()
+
+    // Add activity specs
+    const ActivitySpecRepository = repository.getActivitySpecRepository()
+    await Promise.all(ACTIVITY_SPECS.map((spec) => ActivitySpecRepository._insert(spec)))
+
+    // Add sensor specs
+    const SensorSpecRepository = repository.getSensorSpecRepository()
+    await Promise.all(SENSOR_SPECS.map((spec) => SensorSpecRepository._insert(spec)))
+
+
+    for(let i = 1; i <= RESEARCHER_COUNT; i++) {
+        // Create researcher and study
+        const researcherId = await ResearcherRepository._insert({
+            name: `Researcher ${i}`,
+            email: `researcher_${i}@${TEST_EMAIL_DOMAIN}`,
+            address: `Researcher ${i} address`
+        })
+        const studyId = await StudyRepository._insert(
+            researcherId,
+            {
+                name: `Study ${i}`,
+                isMessagingEnabled: true
+            }
+        )
+
+        // Create Researcher Credential
+        CredentialRepository._insert(researcherId, {
+            origin: researcherId,
+            access_key: `researcher_${i}@${TEST_EMAIL_DOMAIN}`,
+            secret_key: TEST_PASSWORD,
+            description: `Researcher ${i} Test Credential`
+        })
+
+        // Create sensors and activities
+        const activityIds = await Promise.all(ACTIVITIES.map((activity) => ActivityRepository._insert(studyId, activity)))
+        const sensorIds = await Promise.all(SENSORS.map((sensor) => SensorRepository._insert(studyId, sensor)))
+
+        // Create participants
+        for (let j=1; j <= PER_STUDY_PARTICIPANT_COUNT; j++) {
+            const participantId = await ParticipantRepository._insert(studyId, {})
+
+            CredentialRepository._insert(participantId.id, {
+                origin: participantId.id, 
+                access_key: `participant_${i}_${j}@${TEST_EMAIL_DOMAIN}`,
+                secret_key: TEST_PASSWORD,
+                description: `Participant ${j} Test Credential`,
+                // username: participantId.id
+            })
+        }
+    }
+
+    // Add Miscellaneous Tags
+    await TypeRepository._set(
+        undefined,
+        "*",
+        '', // type_id => How is it set to null?
+        'lamp.dashboard.security_preferences',
+        '{"password_rule":"^.*(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*$"}'
+    )
+
+}
+
+console.log("=== START ===")
+loadTestData().then(() => {console.log("=== END ==="); exit(0)})

--- a/src/repository/mongo/ActivityRepository.ts
+++ b/src/repository/mongo/ActivityRepository.ts
@@ -5,7 +5,6 @@ import { MongoClientDB } from "../Bootstrap"
 
 export class ActivityRepository implements ActivityInterface {
   public async _select(id: string | null, parent = false, ignore_binary = false): Promise<Activity[]> {
-    console.log("sdsFetching acTivity--")
     //aggregate will give faster results (particulary when projection in query is applied, 2sec -find, 0.5 sec-aggregate)
     const data = await MongoClientDB.collection("activity")
       .aggregate([

--- a/src/service/ActivityEventService.ts
+++ b/src/service/ActivityEventService.ts
@@ -23,13 +23,13 @@ export class ActivityEventService {
   ) {
     const ActivityEventRepository = new Repository().getActivityEventRepository()
     limit = Math.min(Math.max(limit ?? LIMIT_NAN, -LIMIT_MAX), LIMIT_MAX)
-    participant_id = await _verify(auth, ["self", "sibling", "parent"], participant_id)
+    participant_id = await _verify(auth, ["self", "parent"], participant_id)
     return await ActivityEventRepository._select(participant_id, ignore_binary, origin, from, to, limit)
   }
 
   public static async create(auth: any, participant_id: string, activity_events: any[]) {
     const ActivityEventRepository = new Repository().getActivityEventRepository()
-    participant_id = await _verify(auth, ["self", "sibling", "parent"], participant_id)
+    participant_id = await _verify(auth, ["self", "parent"], participant_id)
     let data = await ActivityEventRepository._insert(participant_id, activity_events)
 
     //publishing data for activity_event add api((Token will be created in PubSubAPIListenerQueue consumer, as request is assumed as array and token should be created individually)

--- a/src/service/ActivityService.ts
+++ b/src/service/ActivityService.ts
@@ -11,7 +11,7 @@ export class ActivityService {
   public static async list(auth: any, study_id: string, ignore_binary: boolean, sibling = false) {
     const ActivityRepository = new Repository().getActivityRepository()
     const TypeRepository = new Repository().getTypeRepository()
-    study_id = await _verify(auth, ["self", "sibling", "parent"], study_id)
+    study_id = await _verify(auth, ["self", "parent"], study_id)
     if (sibling) {
       const parent_id = await TypeRepository._owner(study_id)
       if (parent_id === null) throw new Error("403.invalid-sibling-ownership")
@@ -22,7 +22,7 @@ export class ActivityService {
 
   public static async create(auth: any, study_id: string, activity: any) {
     const ActivityRepository = new Repository().getActivityRepository()
-    study_id = await _verify(auth, ["self", "sibling", "parent"], study_id)
+    study_id = await _verify(auth, ["self", "parent"], study_id)
     const data = await ActivityRepository._insert(study_id, activity)
 
     //publishing data for activity add api with token = study.{study_id}.activity.{_id}
@@ -69,7 +69,7 @@ export class ActivityService {
   public static async set(auth: any, activity_id: string, activity: any | null) {
     const ActivityRepository = new Repository().getActivityRepository()
     const TypeRepository = new Repository().getTypeRepository()
-    activity_id = await _verify(auth, ["self", "sibling", "parent"], activity_id)
+    activity_id = await _verify(auth, ["self", "parent"], activity_id)
     if (activity === null) {
       const parent = (await TypeRepository._parent(activity_id)) as any
       const data = await ActivityRepository._delete(activity_id)

--- a/src/service/ActivitySpecService.ts
+++ b/src/service/ActivitySpecService.ts
@@ -9,7 +9,7 @@ export class ActivitySpecService {
 
   public static async list(auth: any, parent_id: null, ignore_binary?: boolean) {
     const ActivitySpecRepository = new Repository().getActivitySpecRepository()
-    const _ = await _verify(auth, ["self", "sibling", "parent"])
+    const _ = await _verify(auth, ["self", "parent"])
     return await ActivitySpecRepository._select(parent_id, ignore_binary)
   }
 
@@ -21,7 +21,7 @@ export class ActivitySpecService {
 
   public static async get(auth: any, activity_spec_id: string) {
     const ActivitySpecRepository = new Repository().getActivitySpecRepository()
-    const _ = await _verify(auth, ["self", "sibling", "parent"])
+    const _ = await _verify(auth, ["self", "parent"])
     return await ActivitySpecRepository._select(activity_spec_id)
   }
 

--- a/src/service/ParticipantService.ts
+++ b/src/service/ParticipantService.ts
@@ -11,7 +11,7 @@ export class ParticipantService {
   public static async list(auth: any, study_id: string, sibling = false) {
     const ParticipantRepository = new Repository().getParticipantRepository()
     const TypeRepository = new Repository().getTypeRepository()
-    study_id = await _verify(auth, ["self", "sibling", "parent"], study_id)
+    study_id = await _verify(auth, ["self", "parent"], study_id)
     if (sibling) {
       const parent_id = await TypeRepository._owner(study_id)
       if (parent_id === null) throw new Error("403.invalid-sibling-ownership")
@@ -23,7 +23,7 @@ export class ParticipantService {
   // TODO: activity/* and sensor/* entry
   public static async create(auth: any, study_id: string, participant: any) {
     const ParticipantRepository = new Repository().getParticipantRepository()
-    study_id = await _verify(auth, ["self", "sibling", "parent"], study_id)
+    study_id = await _verify(auth, ["self", "parent"], study_id)
     const data = await ParticipantRepository._insert(study_id, participant)
 
     //publishing data for participant add api with token = study.{study_id}.participant.{_id}
@@ -51,14 +51,14 @@ export class ParticipantService {
 
   public static async get(auth: any, participant_id: string) {
     const ParticipantRepository = new Repository().getParticipantRepository()
-    participant_id = await _verify(auth, ["self", "sibling", "parent"], participant_id)
+    participant_id = await _verify(auth, ["self", "parent"], participant_id)
     return await ParticipantRepository._select(participant_id)
   }
 
   public static async set(auth: any, participant_id: string, participant: any | null) {
     const ParticipantRepository = new Repository().getParticipantRepository()
     const TypeRepository = new Repository().getTypeRepository()
-    participant_id = await _verify(auth, ["self", "sibling", "parent"], participant_id)
+    participant_id = await _verify(auth, ["self", "parent"], participant_id)
     if (participant === null) {
       //find the study id before delete, as it cannot be fetched after delete
       const parent = (await TypeRepository._parent(participant_id)) as any

--- a/src/service/Security.ts
+++ b/src/service/Security.ts
@@ -31,6 +31,10 @@ export async function _verify(
   authType: Array<"self" | "sibling" | "parent"> /* 'root' = [] */,
   authObject?: string | null
 ): Promise<string> {
+  function authTypeMatches(targetAuthType: Array<"self" | "sibling" | "parent">) {
+    return (targetAuthType.length === authType.length && 
+            authType.every((v: "self" | "sibling" | "parent") => targetAuthType.includes(v)))
+  }
   const TypeRepository = new Repository().getTypeRepository()
 
   // If an actual AuthSubject was not provided, create one first.
@@ -53,7 +57,7 @@ export async function _verify(
   
   // Check if `authObject` and `authSubject` are the same || authenticated for  resource * 
   if ((!isRoot && authType.includes("self") && (authSubject.origin === authObject))
-      || (JSON.stringify(authType) === JSON.stringify(["self", "sibling", "parent"]) && authObject === undefined))
+      || (authTypeMatches(["parent", "self"]) && authObject === undefined))
     return authObject as any 
   
   // Optimization.

--- a/src/service/SensorEventService.ts
+++ b/src/service/SensorEventService.ts
@@ -23,14 +23,14 @@ export class SensorEventService {
     limit: number | undefined
   ) {
     const SensorEventRepository = new Repository().getSensorEventRepository()
-    participant_id = await _verify(auth, ["self", "sibling", "parent"], participant_id)
+    participant_id = await _verify(auth, ["self", "parent"], participant_id)
     limit = Math.min(Math.max(limit ?? LIMIT_NAN, -LIMIT_MAX), LIMIT_MAX)
     return await SensorEventRepository._select(participant_id, ignore_binary,origin, from, to, limit)
   }
 
   public static async create(auth: any, participant_id: string, sensor_events: any[]) {
     const SensorEventRepository = new Repository().getSensorEventRepository()
-    participant_id = await _verify(auth, ["self", "sibling", "parent"], participant_id)
+    participant_id = await _verify(auth, ["self", "parent"], participant_id)
     let data = {}
     //check for the existance of cache size and redis host
     if (!!process.env.REDIS_HOST) {

--- a/src/service/SensorService.ts
+++ b/src/service/SensorService.ts
@@ -11,7 +11,7 @@ export class SensorService {
   public static async list(auth: any, study_id: string, ignore_binary: boolean, sibling: boolean = false) {
     const SensorRepository = new Repository().getSensorRepository()
     const TypeRepository = new Repository().getTypeRepository()
-    study_id = await _verify(auth, ["self", "sibling", "parent"], study_id)
+    study_id = await _verify(auth, ["self", "parent"], study_id)
     if (sibling) {
       const parent_id = await TypeRepository._owner(study_id)
       if (parent_id === null) throw new Error("403.invalid-sibling-ownership")
@@ -22,7 +22,7 @@ export class SensorService {
 
   public static async create(auth: any, study_id: string, sensor: any) {
     const SensorRepository = new Repository().getSensorRepository()
-    study_id = await _verify(auth, ["self", "sibling", "parent"], study_id)
+    study_id = await _verify(auth, ["self", "parent"], study_id)
     const data = await SensorRepository._insert(study_id, sensor)
 
     //publishing data for sensor add api with token = study.{study_id}.sensor.{_id}
@@ -64,7 +64,7 @@ export class SensorService {
   public static async set(auth: any, sensor_id: string, sensor: any | null) {
     const SensorRepository = new Repository().getSensorRepository()
     const TypeRepository = new Repository().getTypeRepository()
-    sensor_id = await _verify(auth, ["self", "sibling", "parent"], sensor_id)
+    sensor_id = await _verify(auth, ["self", "parent"], sensor_id)
     if (sensor === null) {
       //find the study id before delete, as it cannot be fetched after delete
       const parent = (await TypeRepository._parent(sensor_id)) as any

--- a/src/service/SensorSpecService.ts
+++ b/src/service/SensorSpecService.ts
@@ -9,7 +9,7 @@ export class SensorSpecService {
 
   public static async list(auth: any, parent_id: null, ignore_binary?: boolean) {
     const SensorSpecRepository = new Repository().getSensorSpecRepository()
-    const _ = await _verify(auth, ["self", "sibling", "parent"])
+    const _ = await _verify(auth, ["self", "parent"])
     return await SensorSpecRepository._select(parent_id, ignore_binary)
   }
 
@@ -21,7 +21,7 @@ export class SensorSpecService {
 
   public static async get(auth: any, sensor_spec_id: string) {
     const SensorSpecRepository = new Repository().getSensorSpecRepository()
-    const _ = await _verify(auth, ["self", "sibling", "parent"])
+    const _ = await _verify(auth, ["self", "parent"])
     return await SensorSpecRepository._select(sensor_spec_id)
   }
 


### PR DESCRIPTION
## Summary
- Cherry-pick of the sibling permissions fix from #287 onto `release/v2`
- Removes `"sibling"` from `_verify` auth calls on participant data routes, preventing participants from accessing other participants' data within the same study

## Affected routes
- ActivityEventService (list, create)
- SensorEventService (list, create)
- ActivityService (list, create by study; set by id)
- SensorService (list, create by study; set by id)
- ParticipantService (all routes)
- ActivitySpecService (list, get)
- SensorSpecService (list, get)

Will be tagged as `v2.0.1` on `release/v2` after merge.